### PR TITLE
Fixed compilation warnings on Linux

### DIFF
--- a/include/maidsafe/routing/parameters.h
+++ b/include/maidsafe/routing/parameters.h
@@ -58,7 +58,7 @@ struct Parameters {
   static unsigned int max_send_retry;
   static unsigned int ack_timeout;
   static unsigned int firewall_history_cleanup_factor;
-  static unsigned int firewall_message_life_in_seconds;
+  static std::chrono::seconds firewall_message_life;
   static unsigned int public_key_holding_time;
   static bool caching;
 

--- a/src/maidsafe/routing/acknowledgement.cc
+++ b/src/maidsafe/routing/acknowledgement.cc
@@ -182,8 +182,9 @@ bool Acknowledgement::HandleGroupMessage(const protobuf::Message& message) {
     return true;
   }
 
-  auto expected(std::min(static_cast<unsigned int>(it->requested_peers.size()),
-                         Parameters::group_size / 2));
+  using expected_type = decltype(it->requested_peers.begin())::difference_type;
+  auto expected(std::min<expected_type>(it->requested_peers.size(),
+                                        Parameters::group_size / 2));
   if (std::count_if(it->requested_peers.begin(), it->requested_peers.end(),
                     [](const std::pair<NodeId, GroupMessageAckStatus>& member) {
                       return member.second == GroupMessageAckStatus::kSuccess;

--- a/src/maidsafe/routing/firewall.cc
+++ b/src/maidsafe/routing/firewall.cc
@@ -56,7 +56,7 @@ void Firewall::Remove(std::unique_lock<std::mutex>& lock) {
   auto upper(std::upper_bound(
       std::begin(history_), std::end(history_), dummy,
       [this](const ProcessedEntry& lhs, const ProcessedEntry& rhs) {
-        return (lhs.birth_time - rhs.birth_time < Parameters::firewall_message_life_in_seconds);
+        return (lhs.birth_time - rhs.birth_time < Parameters::firewall_message_life);
       }));
   if (upper != std::end(history_))
     history_.erase(std::begin(history_), upper);

--- a/src/maidsafe/routing/firewall.h
+++ b/src/maidsafe/routing/firewall.h
@@ -19,14 +19,13 @@
 #ifndef MAIDSAFE_ROUTING_FIREWALL_H_
 #define MAIDSAFE_ROUTING_FIREWALL_H_
 
-#include <time.h>
-
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/global_fun.hpp"
 #include "boost/multi_index/mem_fun.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/identity.hpp"
 
+#include "maidsafe/common/clock.h"
 #include "maidsafe/routing/api_config.h"
 
 namespace maidsafe {
@@ -51,12 +50,12 @@ class Firewall {
 
   struct ProcessedEntry {
     ProcessedEntry(const NodeId& source_in, int32_t messsage_id_in)
-        : source(source_in), message_id(messsage_id_in), birth_time(std::time(NULL)) {}
+        : source(source_in), message_id(messsage_id_in), birth_time(common::Clock::now()) {}
     ProcessedEntry Key() const { return *this; }
-    std::time_t BirthTime() const { return birth_time; }
+    common::Clock::time_point BirthTime() const { return birth_time; }
     NodeId source;
     int32_t message_id;
-    std::time_t birth_time;
+    common::Clock::time_point birth_time;
   };
 
  private:
@@ -67,7 +66,7 @@ class Firewall {
       boost::multi_index::indexed_by<
           boost::multi_index::ordered_unique<boost::multi_index::identity<ProcessedEntry>>,
       boost::multi_index::ordered_non_unique<
-          BOOST_MULTI_INDEX_CONST_MEM_FUN(ProcessedEntry, std::time_t, BirthTime)>
+        BOOST_MULTI_INDEX_CONST_MEM_FUN(ProcessedEntry, common::Clock::time_point, BirthTime)>
     >
   > ProcessedEntrySet;
 

--- a/src/maidsafe/routing/parameters.cc
+++ b/src/maidsafe/routing/parameters.cc
@@ -50,7 +50,7 @@ unsigned int Parameters::accepted_distance_tolerance(1);
 unsigned int Parameters::max_send_retry(3);
 unsigned int Parameters::ack_timeout(5);
 unsigned int Parameters::firewall_history_cleanup_factor(5000);
-unsigned int Parameters::firewall_message_life_in_seconds(300);
+std::chrono::seconds Parameters::firewall_message_life(300);
 unsigned int Parameters::public_key_holding_time(30);
 unsigned int Parameters::unidirectional_interest_range(Parameters::closest_nodes_size * 2);
 std::chrono::steady_clock::duration Parameters::local_retreival_timeout(std::chrono::seconds(2));


### PR DESCRIPTION
There were two compiler warnings (see below). The firewall.cc fix switches from <ctype> to <chrono>. The acknowledgement.cc fix uses decltype, and I am not too proud of it, but it does the trick.

/home/breese/src/maidsafe/maidsafe/src/routing/src/maidsafe/routing/firewall.cc:59:63: error: comparison between signed and unsigned
 integer expressions [-Werror=sign-compare]  
         return (lhs.birth_time - rhs.birth_time < Parameters::firewall_message_life_in_seconds);

/home/breese/src/maidsafe/maidsafe/src/routing/src/maidsafe/routing/acknowledgement.cc:190:27: error: comparison between signed and 
unsigned integer expressions [-Werror=sign-compare]  
                     }) == expected) {
