### PR TITLE
update to allow bootstrap by sending a find_group for your own ID.

### DIFF
--- a/src/maidsafe/routing/connection_manager.h
+++ b/src/maidsafe/routing/connection_manager.h
@@ -97,6 +97,7 @@ class ConnectionManager {
   }
 
   bool CloseGroupMember(const Address& their_id);
+  uint32_t Size() { return routing_table_.Size(); }
 
  private:
   boost::optional<CloseGroupDifference> GroupChanged();


### PR DESCRIPTION
Process is Send a connect to a botostrap node. Send find_group and the node should start up
in zero state we will alter the current Quorumsize as the routing table grows.
We will make a node check its local network fro 5483 and in this way even a damaged bootstrap file is OK even in testing